### PR TITLE
Set Chinese as default language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CowCatVPN — Stay Connected in China</title>
-  <meta name="description" content="Traveling to China soon? Prepare your VPN and stay connected to your favorite apps. No web signup. Start in Telegram.">
+  <title>CowCatVPN — 在中国依然畅连</title>
+  <meta name="description" content="即将前往中国？提前准备好 VPN，轻松访问常用应用。无需网页注册，直接在 Telegram 开始。">
   <link rel="icon" href="assets/favicon.png">
   <style>
     :root {
@@ -117,27 +117,27 @@
         <img src="assets/hero-banner.jpg" alt="Hero banner" loading="lazy">
       </picture>
 
-      <h1 id="title">Traveling to China soon?</h1>
-      <p class="lead" id="subtitle">Some of your favorite apps won’t work there. Prepare your VPN before arrival and stay connected.</p>
+      <h1 id="title">即将前往中国？</h1>
+      <p class="lead" id="subtitle">许多常用应用在中国无法使用。请在抵达前配置好 VPN，保持连接无忧。</p>
       <div class="cta">
-        <a class="btn primary" id="btn-bot" target="_blank">🚀 Start in Telegram Bot</a>
-        <a class="btn secondary" id="btn-channel" href="https://t.me/CowCatVPN" target="_blank">📢 Join Telegram Channel</a>
+        <a class="btn primary" id="btn-bot" href="https://t.me/CowCatVPNbot?start=zh_googleads" target="_blank">🚀 通过 Telegram Bot 启动</a>
+        <a class="btn secondary" id="btn-channel" href="https://t.me/CowCatVPN" target="_blank">📢 加入 Telegram 频道</a>
       </div>
     </section>
 
     <section class="card">
-      <h3 id="how-title">How it works</h3>
+      <h3 id="how-title">使用步骤</h3>
       <ol id="how-list">
-        <li>Click “Start in Telegram Bot”.</li>
-        <li>Choose a plan or start a trial.</li>
-        <li>Get your server details instantly and connect.</li>
+        <li>点击“通过 Telegram Bot 启动”。</li>
+        <li>选择套餐或开启试用。</li>
+        <li>立即获取服务器信息并连接。</li>
       </ol>
-      <p class="tiny muted" id="note">Note: Always use VPNs in accordance with local laws and platform policies.</p>
+      <p class="tiny muted" id="note">注意：请在遵守当地法律与平台政策的前提下使用 VPN。</p>
     </section>
   </main>
 
   <footer id="footer">
-    © 2025 CowCatVPN · Stay Connected Worldwide
+    © 2025 CowCatVPN · 畅连全球
   </footer>
 
 <script>
@@ -174,11 +174,13 @@
 
   function getLang() {
     const params = new URLSearchParams(window.location.search);
-    return params.get("lang") || "en"; // 默认英文
+    return params.get("lang") || "zh"; // 默认中文
   }
 
   function applyLang(lang) {
     const t = translations[lang] || translations.en;
+
+    document.documentElement.lang = lang;
 
     document.getElementById("title").textContent = t.title;
     document.getElementById("subtitle").textContent = t.subtitle;


### PR DESCRIPTION
## Summary
- set the default locale of the landing page to Chinese, including the document language, hero copy, and CTA content
- ensure the Chinese Telegram bot link is present by default and keep text synchronized when switching languages
- update the script to change the document language attribute when toggling locales

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d56947752c832ab04e671cc9a2d2b4